### PR TITLE
Updated Thicc Saber to v1.0.0

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -1,1 +1,16 @@
-{}
+{
+    "1.17.1": [
+        {
+            "name": "Thicc Saber",
+            "description": "A simple mod which allows you to control the dimensions of notes!",
+            "id": "ThiccSaber",
+            "version": "1.0.0",
+            "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/v2.1.5/Thicc_Saber-v2.1.5.qmod",
+            "cover": "",
+            "author": {
+                "name": "Bobby Shmurner",
+                "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Updated Thicc Saber to v1.0.0 for Beat Saber version 1.17.1.

You can check out the release [Here](https://github.com/BobbyShmurner/ThiccSaber/releases/tag/v2.1.5)
You can download the QMod [Here](https://github.com/BobbyShmurner/ThiccSaber/releases/download/v2.1.5/Thicc_Saber-v2.1.5.qmod)
You can check out the build action [Here](https://github.com/BobbyShmurner/ThiccSaber/actions/runs/1954100812)

**Notes:**
- I didn't originally have a fork of the mod repo, so the workflow created one for me
- There were no mods found for the version 1.17.1, so a new verion entry was created
- "cover" was not specified, and "cover.png" could not be found in the root of the repo, so no cover was set