### PR TITLE
Added No Promo v1.1.0 to the mod repo

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -13,5 +13,20 @@
                 "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"
             }
         }
+    ],
+    "1.19.1": [
+        {
+            "name": "No Promo",
+            "description": "Yeets the promo button on the main menu",
+            "id": "nopromo",
+            "version": "1.1.0",
+            "downloadLink": "https://github.com/cal117/NoPromo/releases/download/1.1.0/NoPromo-1.1.0+1191.qmod",
+            "source": "https://github.com/cal117/NoPromo/",
+            "cover": "https://raw.githubusercontent.com/cal117/NoPromo/master/cover.png",
+            "author": {
+                "name": "cal117",
+                "icon": "https://github.com/cal117.png"
+            }
+        }
     ]
 }


### PR DESCRIPTION
Added No Promo v1.1.0 to the mod repo for Beat Saber version 1.19.1.

You can check out the release [Here](https://github.com/cal117/NoPromo/releases/tag/)
You can download the QMod [Here](https://github.com/cal117/NoPromo/releases/download//)
You can check out the build action [Here](https://github.com/cal117/NoPromo/actions/runs/1959835965)

**Notes:**
- There were no mods found for the version 1.19.1, so a new verion entry was created