### PR TITLE
Added SearchFixes v1.2.0 to the mod repo

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -12,13 +12,15 @@
                 "name": "Bobby Shmurner",
                 "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"
             }
-        },
+        }
+    ],
+    "1.21.0": [
         {
             "name": "SearchFixes",
             "description": "An improved search algorithm for Beat Saber",
             "id": "SearchFixes",
-            "version": "1.2.0",
-            "downloadLink": "https://github.com/FranciscoRibeiro03/SearchFixesQuest/releases/download/v1.2.0/SearchFixes.qmod",
+            "version": "1.2.1",
+            "downloadLink": "https://github.com/FranciscoRibeiro03/SearchFixesQuest/releases/download/v1.2.1/SearchFixes.qmod",
             "source": "https://github.com/FranciscoRibeiro03/SearchFixesQuest/",
             "cover": "",
             "author": {

--- a/mods.json
+++ b/mods.json
@@ -12,6 +12,19 @@
                 "name": "Bobby Shmurner",
                 "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"
             }
+        },
+        {
+            "name": "SearchFixes",
+            "description": "An improved search algorithm for Beat Saber",
+            "id": "SearchFixes",
+            "version": "1.2.0",
+            "downloadLink": "https://github.com/FranciscoRibeiro03/SearchFixesQuest/releases/download/v1.2.0/SearchFixes.qmod",
+            "source": "https://github.com/FranciscoRibeiro03/SearchFixesQuest/",
+            "cover": "",
+            "author": {
+                "name": "rui2015",
+                "icon": "https://avatars.githubusercontent.com/u/15705566?v=4"
+            }
         }
     ]
 }


### PR DESCRIPTION
Added SearchFixes v1.2.0 to the mod repo for Beat Saber version 1.20.0.

You can check out the release [Here](https://github.com/FranciscoRibeiro03/SearchFixesQuest/releases/tag/v1.2.0)
You can download the QMod [Here](https://github.com/FranciscoRibeiro03/SearchFixesQuest/releases/download/v1.2.0/SearchFixes.qmod)
You can check out the build action [Here](https://github.com/FranciscoRibeiro03/SearchFixesQuest/actions/runs/1983164179)

**Notes:**
- I didn't originally have a fork of the mod repo, so the workflow created one for me
- "cover" was not specified, and "cover.png" could not be found in the root of the repo, so no cover was set