### PR TITLE
Added Vent v1.0.0 to the mod repo

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -27,6 +27,19 @@
                 "name": "You",
                 "icon": "Example.Link.To.Your/pfp.png"
             }
+        },
+        {
+            "name": "Vent",
+            "description": "I swear you just vented...",
+            "id": "vent",
+            "version": "1.0.0",
+            "downloadLink": "https://github.com/cal117/Vent/releases/download/1.0.0/Vent-1.0.0+1210.qmod",
+            "source": "https://github.com/cal117/Vent/",
+            "cover": "https://raw.githubusercontent.com/cal117/Vent/master/cover.png",
+            "author": {
+                "name": "cal117",
+                "icon": "https://github.com/cal117.png"
+            }
         }
     ]
 }


### PR DESCRIPTION
Added Vent v1.0.0 to the mod repo for Beat Saber version 1.21.0.
You can download the QMod [Here](https://github.com/cal117/Vent/releases/download//)
You can check out the build action [Here](https://github.com/cal117/Vent/actions/runs/2157916882)