### PR TITLE
Added No Promo v1.1.0 to the mod repo

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -27,6 +27,19 @@
                 "name": "You",
                 "icon": "Example.Link.To.Your/pfp.png"
             }
+        },
+        {
+            "name": "No Promo",
+            "description": "Yeets the promo button on the main menu",
+            "id": "nopromo",
+            "version": "1.1.0",
+            "downloadLink": "https://github.com/cal117/NoPromo/releases/download/1.1.0/NoPromo-1.1.0+1210.qmod",
+            "source": "https://github.com/cal117/NoPromo/",
+            "cover": "https://raw.githubusercontent.com/cal117/NoPromo/master/cover.png",
+            "author": {
+                "name": "cal117",
+                "icon": "https://github.com/cal117.png"
+            }
         }
     ]
 }


### PR DESCRIPTION
Added No Promo v1.1.0 to the mod repo for Beat Saber version 1.21.0.
You can download the QMod [Here](https://github.com/cal117/NoPromo/releases/download//)
You can check out the build action [Here](https://github.com/cal117/NoPromo/actions/runs/2157924023)