### PR TITLE
Updated Thicc Saber to v1.1.0

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -7,7 +7,7 @@
             "version": "1.1.0",
             "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/v1.1.0/Thicc_Saber-v1.1.0.qmod",
             "source": "https://github.com/BobbyShmurner/ThiccSaber/",
-            "cover": "https://github.com/BobbyShmurner/ThiccSaber/raw/refs/tags/v1.1.0/cover.png",
+            "cover": "https://github.com/BobbyShmurner/ThiccSaber/raw/refs/heads/main/cover.png",
             "author": {
                 "name": "Bobby Shmurner",
                 "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"


### PR DESCRIPTION
Updated Thicc Saber to v1.1.0 for Beat Saber version 1.20.0.
You can download the QMod [Here](https://github.com/BobbyShmurner/ThiccSaber/releases/download//)
You can check out the build action [Here](https://github.com/BobbyShmurner/ThiccSaber/actions/runs/2174009762)
- Testing, just ignore this