### PR TITLE
Added Thicc Saber v1.1.0 to the mod repo

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -7,7 +7,7 @@
             "version": "1.1.0",
             "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/v1.1.0/Thicc_Saber-v1.1.0.qmod",
             "source": "https://github.com/BobbyShmurner/ThiccSaber/",
-            "cover": "https://github.com/BobbyShmurner/ThiccSaber/raw/refs/heads/main/cover.png",
+            "cover": "https://github.com/BobbyShmurner/ThiccSaber/raw/refs/tags/v1.1.0/cover.png",
             "author": {
                 "name": "Bobby Shmurner",
                 "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"
@@ -91,6 +91,19 @@
             "author": {
                 "name": "Metalit",
                 "icon": "https://avatars.githubusercontent.com/u/48568911?v=4"
+            }
+        },
+        {
+            "name": "Thicc Saber",
+            "description": "A simple mod which allows you to control the dimensions of notes!",
+            "id": "ThiccSaber",
+            "version": "1.1.0",
+            "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/v1.1.0/Thicc_Saber-v1.1.0.qmod",
+            "source": "https://github.com/BobbyShmurner/ThiccSaber/",
+            "cover": "https://github.com/BobbyShmurner/ThiccSaber/raw/refs/heads/main/cover.png",
+            "author": {
+                "name": "Bobby Shmurner",
+                "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"
             }
         }
     ]

--- a/mods.json
+++ b/mods.json
@@ -7,7 +7,7 @@
             "version": "1.1.0",
             "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/v1.1.0/Thicc_Saber-v1.1.0.qmod",
             "source": "https://github.com/BobbyShmurner/ThiccSaber/",
-            "cover": "https://github.com/BobbyShmurner/ThiccSaber/raw/refs/tags/v1.1.0/cover.png",
+            "cover": "https://github.com/BobbyShmurner/ThiccSaber/raw/refs/heads/main/cover.png",
             "author": {
                 "name": "Bobby Shmurner",
                 "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"


### PR DESCRIPTION
Added Thicc Saber v1.1.0 to the mod repo for Beat Saber version 1.21.0.
You can download the QMod [Here](https://github.com/BobbyShmurner/ThiccSaber/releases/download//)
You can check out the build action [Here](https://github.com/BobbyShmurner/ThiccSaber/actions/runs/2174099727)
- Testing, just ignore this :)