### PR TITLE
Added SearchFixes v1.2.2 to the mod repo

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -93,5 +93,20 @@
                 "icon": "https://avatars.githubusercontent.com/u/48568911?v=4"
             }
         }
+    ],
+    "1.24.0": [
+        {
+            "name": "SearchFixes",
+            "description": "An improved search algorithm for Beat Saber",
+            "id": "SearchFixes",
+            "version": "1.2.2",
+            "downloadLink": "https://github.com/FranciscoRibeiro03/SearchFixesQuest/releases/download/v1.2.2/SearchFixes.qmod",
+            "source": "https://github.com/FranciscoRibeiro03/SearchFixesQuest/",
+            "cover": "",
+            "author": {
+                "name": "rui2015",
+                "icon": "https://avatars.githubusercontent.com/u/15705566?v=4"
+            }
+        }
     ]
 }


### PR DESCRIPTION
Added SearchFixes v1.2.2 to the mod repo for Beat Saber version 1.24.0.

You can check out the release [Here](https://github.com/FranciscoRibeiro03/SearchFixesQuest/releases/tag/v1.2.2)
You can download the QMod [Here](https://github.com/FranciscoRibeiro03/SearchFixesQuest/releases/download/v1.2.2/SearchFixes.qmod)
You can check out the build action [Here](https://github.com/FranciscoRibeiro03/SearchFixesQuest/actions/runs/2853499240)

**Notes:**
- There were no mods found for the version 1.24.0, so a new verion entry was created
- "cover" was not specified, and "cover.png" could not be found in the root of the repo, so no cover was set