### PR TITLE
Added NoodleExtensions v1.2.1-beta1 to the mod repo

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -177,10 +177,10 @@
             "name": "NoodleExtensions",
             "description": "This adds a host of new things you can do with your maps. Original mod for PC by Aeroluna. Contributions by Fern and Sc2ad.",
             "id": "NoodleExtensions",
-            "version": "1.2.1-beta1",
-            "downloadLink": "https://github.com/StackDoubleFlow/NoodleExtensions/releases/download/v1.2.1/noodle_extensions.qmod",
+            "version": "1.2.2-beta1",
+            "downloadLink": "https://github.com/StackDoubleFlow/NoodleExtensions/releases/download/v1.2.2/noodle_extensions.qmod",
             "source": "https://github.com/StackDoubleFlow/NoodleExtensions/",
-            "cover": "https://github.com/StackDoubleFlow/NoodleExtensions/raw/refs/tags/v1.2.1/cover.png",
+            "cover": "https://github.com/StackDoubleFlow/NoodleExtensions/raw/refs/tags/v1.2.2/cover.png",
             "author": {
                 "name": "StackDoubleFlow",
                 "icon": "https://avatars.githubusercontent.com/u/22183359?v=4"

--- a/mods.json
+++ b/mods.json
@@ -172,6 +172,19 @@
                 "name": "EnderdracheLP, ComputerElite",
                 "icon": "https://computerelite.github.io/assets/person.png"
             }
+        },
+        {
+            "name": "NoodleExtensions",
+            "description": "This adds a host of new things you can do with your maps. Original mod for PC by Aeroluna. Contributions by Fern and Sc2ad.",
+            "id": "NoodleExtensions",
+            "version": "1.2.1-beta1",
+            "downloadLink": "https://github.com/StackDoubleFlow/NoodleExtensions/releases/download/v1.2.1/noodle_extensions.qmod",
+            "source": "https://github.com/StackDoubleFlow/NoodleExtensions/",
+            "cover": "https://github.com/StackDoubleFlow/NoodleExtensions/raw/refs/tags/v1.2.1/cover.png",
+            "author": {
+                "name": "StackDoubleFlow",
+                "icon": "https://avatars.githubusercontent.com/u/22183359?v=4"
+            }
         }
     ]
 }

--- a/mods.json
+++ b/mods.json
@@ -177,10 +177,10 @@
             "name": "NoodleExtensions",
             "description": "This adds a host of new things you can do with your maps. Original mod for PC by Aeroluna. Contributions by Fern and Sc2ad.",
             "id": "NoodleExtensions",
-            "version": "1.2.2-beta1",
-            "downloadLink": "https://github.com/StackDoubleFlow/NoodleExtensions/releases/download/v1.2.2/noodle_extensions.qmod",
+            "version": "1.2.3-beta1",
+            "downloadLink": "https://github.com/StackDoubleFlow/NoodleExtensions/releases/download/v1.2.3/noodle_extensions.qmod",
             "source": "https://github.com/StackDoubleFlow/NoodleExtensions/",
-            "cover": "https://github.com/StackDoubleFlow/NoodleExtensions/raw/refs/tags/v1.2.2/cover.png",
+            "cover": "https://github.com/StackDoubleFlow/NoodleExtensions/raw/refs/tags/v1.2.3/cover.png",
             "author": {
                 "name": "StackDoubleFlow",
                 "icon": "https://avatars.githubusercontent.com/u/22183359?v=4"

--- a/mods.json
+++ b/mods.json
@@ -177,10 +177,10 @@
             "name": "NoodleExtensions",
             "description": "This adds a host of new things you can do with your maps. Original mod for PC by Aeroluna. Contributions by Fern and Sc2ad.",
             "id": "NoodleExtensions",
-            "version": "1.2.3-beta1",
-            "downloadLink": "https://github.com/StackDoubleFlow/NoodleExtensions/releases/download/v1.2.3/noodle_extensions.qmod",
+            "version": "1.2.4-beta1",
+            "downloadLink": "https://github.com/StackDoubleFlow/NoodleExtensions/releases/download/v1.2.4/noodle_extensions.qmod",
             "source": "https://github.com/StackDoubleFlow/NoodleExtensions/",
-            "cover": "https://github.com/StackDoubleFlow/NoodleExtensions/raw/refs/tags/v1.2.3/cover.png",
+            "cover": "https://github.com/StackDoubleFlow/NoodleExtensions/raw/refs/tags/v1.2.4/cover.png",
             "author": {
                 "name": "StackDoubleFlow",
                 "icon": "https://avatars.githubusercontent.com/u/22183359?v=4"


### PR DESCRIPTION
Added NoodleExtensions v1.2.1-beta1 to the mod repo for Beat Saber version 1.24.0.

You can check out the release [Here](https://github.com/StackDoubleFlow/NoodleExtensions/releases/tag/v1.2.1)
You can download the QMod [Here](https://github.com/StackDoubleFlow/NoodleExtensions/releases/download/v1.2.1/noodle_extensions.qmod)
You can check out the build action [Here](https://github.com/StackDoubleFlow/NoodleExtensions/actions/runs/2856096099)

**Notes:**
- I didn't originally have a fork of the mod repo, so the workflow created one for me