### PR TITLE
Added SearchFixes v1.2.3 to the mod repo

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -223,7 +223,7 @@
             "author": {
                 "name": "StackDoubleFlow",
                 "icon": "https://avatars.githubusercontent.com/u/22183359?v=4"
-          }
+            }
         },
         {
             "name": "Chroma",
@@ -301,6 +301,21 @@
             "author": {
                 "name": "BoopetyDoopety, EnderdracheLP",
                 "icon": "https://avatars.githubusercontent.com/u/81266776?s=200&v=4"
+            }
+        }
+    ],
+    "1.25.1": [
+        {
+            "name": "SearchFixes",
+            "description": "An improved search algorithm for Beat Saber",
+            "id": "SearchFixes",
+            "version": "1.2.3",
+            "downloadLink": "https://github.com/FranciscoRibeiro03/SearchFixesQuest/releases/download/v1.2.3/SearchFixes.qmod",
+            "source": "https://github.com/FranciscoRibeiro03/SearchFixesQuest/",
+            "cover": "https://github.com/FranciscoRibeiro03/SearchFixesQuest/raw/refs/tags/v1.2.3/cover.png",
+            "author": {
+                "name": "rui2015",
+                "icon": "https://avatars.githubusercontent.com/u/15705566?v=4"
             }
         }
     ]


### PR DESCRIPTION
Added SearchFixes v1.2.3 to the mod repo for Beat Saber version 1.25.1.

You can check out the release [Here](https://github.com/FranciscoRibeiro03/SearchFixesQuest/releases/tag/v1.2.3)
You can download the QMod [Here](https://github.com/FranciscoRibeiro03/SearchFixesQuest/releases/download/v1.2.3/SearchFixes.qmod)
You can check out the build action [Here](https://github.com/FranciscoRibeiro03/SearchFixesQuest/actions/runs/3297928873)

**Notes:**
- There were no mods found for the version 1.25.1, so a new verion entry was created