### PR TITLE
Updated NoodleExtensions to v1.3.0-beta1

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -213,19 +213,6 @@
             }
         },
         {
-            "name": "NoodleExtensions",
-            "description": "This adds a host of new things you can do with your maps. Original mod for PC by Aeroluna. Contributions by Fern and Sc2ad.",
-            "id": "NoodleExtensions",
-            "version": "1.2.4-beta1",
-            "downloadLink": "https://github.com/StackDoubleFlow/NoodleExtensions/releases/download/v1.2.4/noodle_extensions.qmod",
-            "source": "https://github.com/StackDoubleFlow/NoodleExtensions/",
-            "cover": "https://github.com/StackDoubleFlow/NoodleExtensions/raw/refs/tags/v1.2.4/cover.png",
-            "author": {
-                "name": "StackDoubleFlow",
-                "icon": "https://avatars.githubusercontent.com/u/22183359?v=4"
-          }
-        },
-        {
             "name": "Chroma",
             "description": "Colors!",
             "id": "chroma",
@@ -301,6 +288,19 @@
             "author": {
                 "name": "BoopetyDoopety, EnderdracheLP",
                 "icon": "https://avatars.githubusercontent.com/u/81266776?s=200&v=4"
+            }
+        },
+        {
+            "name": "NoodleExtensions",
+            "description": "This adds a host of new things you can do with your maps. Original mod for PC by Aeroluna. Contributions by Fern and Sc2ad.",
+            "id": "NoodleExtensions",
+            "version": "1.3.0-beta1",
+            "downloadLink": "https://github.com/StackDoubleFlow/NoodleExtensions/releases/download/v1.3.0/noodle_extensions.qmod",
+            "source": "https://github.com/StackDoubleFlow/NoodleExtensions/",
+            "cover": "https://github.com/StackDoubleFlow/NoodleExtensions/raw/refs/tags/v1.3.0/cover.png",
+            "author": {
+                "name": "StackDoubleFlow",
+                "icon": "https://avatars.githubusercontent.com/u/22183359?v=4"
             }
         }
     ]


### PR DESCRIPTION
Updated NoodleExtensions to v1.3.0-beta1 for Beat Saber version 1.24.0.

You can check out the release [Here](https://github.com/StackDoubleFlow/NoodleExtensions/releases/tag/v1.3.0)
You can download the QMod [Here](https://github.com/StackDoubleFlow/NoodleExtensions/releases/download/v1.3.0/noodle_extensions.qmod)
You can check out the build action [Here](https://github.com/StackDoubleFlow/NoodleExtensions/actions/runs/3356763025)